### PR TITLE
📝 Docs: Add documentation for dotenv CLI tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md
+
+## Project Overview
+This repository contains a simple `dotenv` CLI tool written in Go. It loads environment variables from files and command-line arguments before executing a command.
+
+## Project Structure
+- `cmd/dotenv/main.go`: The main entry point and implementation of the CLI tool.
+- `go.mod`: Dependency definition (requires `github.com/joho/godotenv`).
+
+## Development
+- **Language**: Go (v1.15+)
+- **Linting**: Run `go vet ./...` to lint the code.
+- **Testing**: Run `go test ./...` to run tests (currently no tests are implemented, but the command is standard).
+
+## Dependencies
+- `github.com/joho/godotenv`: Used for parsing `.env` files.
+
+## Known Limitations
+- Arguments passed with `--key=value` syntax do not support values containing `=`. For example, `--PATH=/usr/bin:/bin` works, but `--CFLAGS=-DDEBUG=1` will fail parsing.
+- The tool loads `.env` from the current directory by default, which overrides any command-line arguments with the same key.

--- a/cmd/dotenv/main.go
+++ b/cmd/dotenv/main.go
@@ -1,3 +1,5 @@
+// Package main implements the dotenv CLI tool which loads environment variables
+// from files and command-line arguments before executing a command.
 package main
 
 import (
@@ -9,14 +11,17 @@ import (
 	"github.com/joho/godotenv"
 )
 
+// env stores the loaded environment variables.
 var env  = map[string]string{}
 
+// mergeEnv updates the global env map with variables from the provided map.
 func mergeEnv(m map[string]string) {
     for k := range m {
         env[k] = m[k]
     }
 }
 
+// printHelp displays the usage information for the dotenv command.
 func printHelp() {
     println("dotenv [...params] -- command")
     println("params: ")
@@ -24,6 +29,13 @@ func printHelp() {
     println(" --key=value load variable")
 }
 
+// parseEnvTerm parses a single command-line argument to load environment variables.
+//
+// It supports two formats:
+//   - @filename: Loads environment variables from the specified file.
+//   - --key=value: Sets a specific environment variable.
+//
+// Note: The current implementation of --key=value does not support values containing '='.
 func parseEnvTerm(term string) error {
     if term[0] == '@' {
         filename := term[1:]
@@ -54,6 +66,7 @@ func parseEnvTerm(term string) error {
     return nil
 }
 
+// handleError prints the error message and help text, then exits the program with status code 1 if an error occurs.
 func handleError(err error) {
     if err == nil {
         return
@@ -63,6 +76,11 @@ func handleError(err error) {
     os.Exit(1)
 }
 
+// main is the entry point of the application.
+//
+// It parses command-line arguments to load environment variables,
+// loads the default .env file (which overrides CLI arguments),
+// and finally executes the specified command with the populated environment.
 func main() {
     argslen := len(os.Args)
     stripped := make([]string, argslen - 1)
@@ -88,6 +106,7 @@ func main() {
     if !foundDivider {
         handleError(fmt.Errorf("missing divider (--)"))
     }
+    // Load .env file. This overrides any conflicting variables set via CLI arguments.
     parseEnvTerm("@.env")
     cmd := exec.Command(command[0], command[1:]...)
     cmd.Env = os.Environ() // herdar env do pai


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation to the `dotenv` CLI tool. It introduces `AGENTS.md` to outline project conventions and adds Go docstrings to `cmd/dotenv/main.go` to explain the code's behavior, including non-obvious nuances like `.env` file precedence and argument parsing limitations.

## Assumptions
- The project is intended to be used as a CLI wrapper.
- The current behavior (loading `.env` after CLI args, thus overriding them) is intentional or at least the current state of truth to be documented.
- No `mise.toml` exists, so standard Go commands are used for verification.

## Alternatives Not Chosen
- Fixing the logic bug in `parseEnvTerm` where values containing `=` cause errors (out of scope for a docs-only task).
- Changing the precedence of `.env` loading (out of scope).
- Adding `mise.toml` (forbidden by constraints).

## How To Pivot
- If the goal shifts to fixing the logic bugs instead of documenting them, discard these changes and implement `strings.SplitN` in `parseEnvTerm` and reorder the loading logic in `main`.

## Next Knobs
- `cmd/dotenv/main.go`: The `parseEnvTerm` function can be refactored to use `strings.SplitN` to support values with `=`.
- `cmd/dotenv/main.go`: The `main` function can be updated to load `.env` before parsing CLI arguments to allow CLI overrides.


---
*PR created automatically by Jules for task [3827006285820310670](https://jules.google.com/task/3827006285820310670) started by @lucasew*