### PR TITLE
🛠️ Refactor: Extract parsing logic and remove global state

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -24,8 +24,8 @@ jobs:
           go-version: '1.25.5'
 
     - run: mkdir build -p && ls && pwd
-    - run: GOOS=windows GOARCH=amd64 go build -o build/dotenv-windows-amd64.exe ./cmd/dotenv/main.go
-    - run: go build -o build/dotenv-linux-amd64 ./cmd/dotenv/main.go
+    - run: GOOS=windows GOARCH=amd64 go build -o build/dotenv-windows-amd64.exe ./cmd/dotenv
+    - run: go build -o build/dotenv-linux-amd64 ./cmd/dotenv
     - uses: svenstaro/upload-release-action@b98a3b12e86552593f3e4e577ca8a62aa2f3f22b # v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Agent Guidelines
+
+## General Context
+This repository provides a Go CLI tool (`dotenv`) for launching commands with environment variables loaded from specific files or arguments.
+The project relies on standard Go tools (`go test`, `go vet`) and uses `mise` for tool management and task execution.
+
+## Directory Pointers
+- `cmd/dotenv/` -> Entrypoint for the CLI application.
+- `cmd/dotenv/main.go` -> Main logic and execution flow.
+- `cmd/dotenv/parser.go` -> Logic for parsing arguments and files (to be extracted here).
+
+## Coding Guidelines
+- **Go Conventions**: Adhere strictly to Go standard project layout and idiomatic Go formatting.
+- **Global State**: Minimize the use of global state. Inject variables explicitly where possible to maintain modularity.
+- **Error Handling**: Use the centralized error handling function `handleError` in `main.go`. All unrecoverable errors should funnel through this single point rather than using inline `os.Exit` or `log.Fatal` elsewhere.
+- **Single Responsibility**: Each file should have a distinct, well-defined responsibility. Code extraction and separation of concerns are heavily encouraged based on Robert C. Martin's Single Responsibility Principle.
+
+## Testing
+- Tests should live alongside the code they test (e.g. `cmd/dotenv/parser_test.go`).
+- Always run automated checks (`mise run ci` or `go test ./...` and `go vet ./...`) before confirming changes.

--- a/cmd/dotenv/main.go
+++ b/cmd/dotenv/main.go
@@ -5,53 +5,13 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-
-	"github.com/joho/godotenv"
 )
-
-var env  = map[string]string{}
-
-func mergeEnv(m map[string]string) {
-    for k := range m {
-        env[k] = m[k]
-    }
-}
 
 func printHelp() {
     println("dotenv [...params] -- command")
     println("params: ")
     println(" @file.txt load file as dotenv")
     println(" --key=value load variable")
-}
-
-func parseEnvTerm(term string) error {
-    if term[0] == '@' {
-        filename := term[1:]
-        f, err := os.Open(filename)
-        defer f.Close()
-        if err != nil {
-            return err
-        }
-        variables, err := godotenv.Parse(f)
-        if err != nil {
-            return err
-        }
-        mergeEnv(variables)
-        return nil
-    }
-    if strings.HasPrefix(term, "--") {
-        termBody := term[2:]
-        elems := strings.Split(termBody, "=")
-        if len(elems) != 2 {
-            return fmt.Errorf("syntax error near %s", term)
-        }
-        key := elems[0]
-        value := elems[1]
-        env[key] = value
-        return nil
-    }
-    fmt.Printf("warn: ignoring argument '%s'\n", term)
-    return nil
 }
 
 func handleError(err error) {
@@ -64,6 +24,7 @@ func handleError(err error) {
 }
 
 func main() {
+    env := map[string]string{}
     argslen := len(os.Args)
     stripped := make([]string, argslen - 1)
     for i := 1; i < argslen; i++ {
@@ -79,7 +40,7 @@ func main() {
             }
         }
         if !foundDivider {
-            err := parseEnvTerm(stripped[i])
+            err := ParseEnvTerm(stripped[i], env)
             handleError(err)
         } else {
             command = append(command, stripped[i])
@@ -88,7 +49,7 @@ func main() {
     if !foundDivider {
         handleError(fmt.Errorf("missing divider (--)"))
     }
-    parseEnvTerm("@.env")
+    ParseEnvTerm("@.env", env)
     cmd := exec.Command(command[0], command[1:]...)
     cmd.Env = os.Environ() // herdar env do pai
     for k, v := range env {

--- a/cmd/dotenv/main.go
+++ b/cmd/dotenv/main.go
@@ -8,59 +8,59 @@ import (
 )
 
 func printHelp() {
-    println("dotenv [...params] -- command")
-    println("params: ")
-    println(" @file.txt load file as dotenv")
-    println(" --key=value load variable")
+	println("dotenv [...params] -- command")
+	println("params: ")
+	println(" @file.txt load file as dotenv")
+	println(" --key=value load variable")
 }
 
 func handleError(err error) {
-    if err == nil {
-        return
-    }
-    fmt.Println("error: ", err)
-    printHelp()
-    os.Exit(1)
+	if err == nil {
+		return
+	}
+	fmt.Println("error: ", err)
+	printHelp()
+	os.Exit(1)
 }
 
 func main() {
-    env := map[string]string{}
-    argslen := len(os.Args)
-    stripped := make([]string, argslen - 1)
-    for i := 1; i < argslen; i++ {
-        stripped[i - 1] = strings.Trim(os.Args[i], " ")
-    }
-    foundDivider := false
-    command := []string{}
-    for i := 0; i < len(stripped); i++ {
-        if (stripped[i] == "--") {
-            if !foundDivider {
-                foundDivider = true
-                continue
-            }
-        }
-        if !foundDivider {
-            err := ParseEnvTerm(stripped[i], env)
-            handleError(err)
-        } else {
-            command = append(command, stripped[i])
-        }
-    }
-    if !foundDivider {
-        handleError(fmt.Errorf("missing divider (--)"))
-    }
-    ParseEnvTerm("@.env", env)
-    cmd := exec.Command(command[0], command[1:]...)
-    cmd.Env = os.Environ() // herdar env do pai
-    for k, v := range env {
-        cmd.Env = append(cmd.Env, strings.Join([]string{k, v}, "="))
-    }
-    cmd.Stdin = os.Stdin
-    cmd.Stdout = os.Stdout
-    cmd.Stderr = os.Stderr
-    err := cmd.Start()
-    handleError(err)
-    proc, err := cmd.Process.Wait()
-    handleError(err)
-    os.Exit(proc.ExitCode())
+	env := map[string]string{}
+	argslen := len(os.Args)
+	stripped := make([]string, argslen-1)
+	for i := 1; i < argslen; i++ {
+		stripped[i-1] = strings.Trim(os.Args[i], " ")
+	}
+	foundDivider := false
+	command := []string{}
+	for i := 0; i < len(stripped); i++ {
+		if stripped[i] == "--" {
+			if !foundDivider {
+				foundDivider = true
+				continue
+			}
+		}
+		if !foundDivider {
+			err := ParseEnvTerm(stripped[i], env)
+			handleError(err)
+		} else {
+			command = append(command, stripped[i])
+		}
+	}
+	if !foundDivider {
+		handleError(fmt.Errorf("missing divider (--)"))
+	}
+	ParseEnvTerm("@.env", env)
+	cmd := exec.Command(command[0], command[1:]...)
+	cmd.Env = os.Environ() // herdar env do pai
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, strings.Join([]string{k, v}, "="))
+	}
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Start()
+	handleError(err)
+	proc, err := cmd.Process.Wait()
+	handleError(err)
+	os.Exit(proc.ExitCode())
 }

--- a/cmd/dotenv/parser.go
+++ b/cmd/dotenv/parser.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/joho/godotenv"
+)
+
+func mergeEnv(env map[string]string, m map[string]string) {
+	for k := range m {
+		env[k] = m[k]
+	}
+}
+
+// ParseEnvTerm parses a specific term, modifying the provided environment map.
+func ParseEnvTerm(term string, env map[string]string) error {
+	if term[0] == '@' {
+		filename := term[1:]
+		f, err := os.Open(filename)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		variables, err := godotenv.Parse(f)
+		if err != nil {
+			return err
+		}
+		mergeEnv(env, variables)
+		return nil
+	}
+	if strings.HasPrefix(term, "--") {
+		termBody := term[2:]
+		elems := strings.SplitN(termBody, "=", 2)
+		if len(elems) != 2 {
+			return fmt.Errorf("syntax error near %s", term)
+		}
+		key := elems[0]
+		value := elems[1]
+		env[key] = value
+		return nil
+	}
+	fmt.Printf("warn: ignoring argument '%s'\n", term)
+	return nil
+}

--- a/cmd/dotenv/parser_test.go
+++ b/cmd/dotenv/parser_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseEnvTerm_Args(t *testing.T) {
+	env := map[string]string{}
+
+	// Test simple key value
+	err := ParseEnvTerm("--FOO=bar", env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if env["FOO"] != "bar" {
+		t.Errorf("expected FOO=bar, got %v", env["FOO"])
+	}
+
+	// Test value with equal sign
+	err = ParseEnvTerm("--API_KEY=123=456", env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if env["API_KEY"] != "123=456" {
+		t.Errorf("expected API_KEY=123=456, got %v", env["API_KEY"])
+	}
+
+	// Test invalid arg
+	err = ParseEnvTerm("--INVALID", env)
+	if err == nil {
+		t.Errorf("expected syntax error, got nil")
+	}
+}
+
+func TestParseEnvTerm_File(t *testing.T) {
+	env := map[string]string{}
+	tmpDir := t.TempDir()
+	envFile := filepath.Join(tmpDir, ".env")
+
+	// Write dummy .env
+	content := []byte("DB_HOST=localhost\nDB_PASS=secret=pass")
+	if err := os.WriteFile(envFile, content, 0644); err != nil {
+		t.Fatalf("failed to write tmp env file: %v", err)
+	}
+
+	err := ParseEnvTerm("@"+envFile, env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if env["DB_HOST"] != "localhost" {
+		t.Errorf("expected DB_HOST=localhost, got %v", env["DB_HOST"])
+	}
+
+	if env["DB_PASS"] != "secret=pass" {
+		t.Errorf("expected DB_PASS=secret=pass, got %v", env["DB_PASS"])
+	}
+}

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,6 @@
+[tools]
+go = "1.21.8"
+
+[tasks]
+ci = "go vet ./... && go test ./..."
+test = "go test ./..."

--- a/package.nix
+++ b/package.nix
@@ -10,6 +10,8 @@ buildGoModule {
 
   src = ./.;
 
+  subPackages = [ "cmd/dotenv" ];
+
   meta = with lib; {
     description = "Dotenv as a binary that loads the dotenv and calls the program";
     homepage = "https://github.com/lucasew/dotenv";


### PR DESCRIPTION
# Assumptions
- Extracted parser logic needs its own file `parser.go` to abide by SRP.
- Removed global `env` variable and instead passed a map locally.
- Replaced `strings.Split` with `strings.SplitN` when parsing `--key=value` formats so that values with equal signs do not crash the parser.
- Setup `mise.toml` to install dependencies and standardize testing.
- Created `AGENTS.md` with guidelines.

# Alternatives Not Chosen
- Continuing to use a global state to make the refactor smaller. This was skipped in favor of clean architecture.

# How To Pivot
- If a different error handling mechanism is preferred, the `handleError` centralization in `main.go` can be easily modified.

# Next Knobs
- The parsing logic in `parser.go` can be extended to support interpolation.
- More complex file resolution logic could be added instead of just basic `os.Open`.

---
*PR created automatically by Jules for task [8484113241067649983](https://jules.google.com/task/8484113241067649983) started by @lucasew*