### PR TITLE
🛠️ Refactor: Extract parsing logic and remove global state

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -24,8 +24,8 @@ jobs:
           go-version: '1.25.5'
 
     - run: mkdir build -p && ls && pwd
-    - run: GOOS=windows GOARCH=amd64 go build -o build/dotenv-windows-amd64.exe ./cmd/dotenv/main.go
-    - run: go build -o build/dotenv-linux-amd64 ./cmd/dotenv/main.go
+    - run: GOOS=windows GOARCH=amd64 go build -o build/dotenv-windows-amd64.exe ./cmd/dotenv
+    - run: go build -o build/dotenv-linux-amd64 ./cmd/dotenv
     - uses: svenstaro/upload-release-action@b98a3b12e86552593f3e4e577ca8a62aa2f3f22b # v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Project Conventions
+
+## General Philosophy
+- **Minimize Global State:** Passing the state explicitly as parameters to functions allows them to be purer and easier to test.
+- **Centralized Error Reporting:** The project must have a single centralized error-reporting function. All logic flows must pipe unexpected or critical errors through this function. In `cmd/dotenv/main.go`, `handleError` serves this purpose.
+
+## Naming & Directory Structure
+- Follow standard Go package layout conventions.
+- The main entrypoint is `cmd/dotenv/main.go`.
+- Parsing logic for CLI arguments is extracted to `cmd/dotenv/parser.go`.
+- Things that change together should live together (colocation).
+
+## Code Style & Rules
+- **Formatting:** Always run `go fmt ./...` before committing. Strict CI checks will fail if Go code is not properly formatted.
+- **Dependency Management:** Nix (`package.nix`, `default.nix`) is used with `buildGoModule`. When modifying Go package structures or entrypoints, ensure `subPackages` in `package.nix` is correctly configured to instruct Nix where to build, preventing CI build failures.
+
+## Build and Tests
+- To build the application: `go build -o build/dotenv ./cmd/dotenv`
+- To verify changes locally: `go vet ./... && go test ./...`
+- When compiling, target the package directory `./cmd/dotenv` rather than the `main.go` file directly to ensure all package files are included.
+- Tooling such as `mise` must be installed via direct standalone binary downloads rather than `curl | sh` scripts. Verification tools run using `mise` (e.g. `mise run ci` or `mise run test`).

--- a/cmd/dotenv/main.go
+++ b/cmd/dotenv/main.go
@@ -5,101 +5,62 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-
-	"github.com/joho/godotenv"
 )
 
-var env  = map[string]string{}
-
-func mergeEnv(m map[string]string) {
-    for k := range m {
-        env[k] = m[k]
-    }
-}
-
 func printHelp() {
-    println("dotenv [...params] -- command")
-    println("params: ")
-    println(" @file.txt load file as dotenv")
-    println(" --key=value load variable")
-}
-
-func parseEnvTerm(term string) error {
-    if term[0] == '@' {
-        filename := term[1:]
-        f, err := os.Open(filename)
-        defer f.Close()
-        if err != nil {
-            return err
-        }
-        variables, err := godotenv.Parse(f)
-        if err != nil {
-            return err
-        }
-        mergeEnv(variables)
-        return nil
-    }
-    if strings.HasPrefix(term, "--") {
-        termBody := term[2:]
-        elems := strings.Split(termBody, "=")
-        if len(elems) != 2 {
-            return fmt.Errorf("syntax error near %s", term)
-        }
-        key := elems[0]
-        value := elems[1]
-        env[key] = value
-        return nil
-    }
-    fmt.Printf("warn: ignoring argument '%s'\n", term)
-    return nil
+	println("dotenv [...params] -- command")
+	println("params: ")
+	println(" @file.txt load file as dotenv")
+	println(" --key=value load variable")
 }
 
 func handleError(err error) {
-    if err == nil {
-        return
-    }
-    fmt.Println("error: ", err)
-    printHelp()
-    os.Exit(1)
+	if err == nil {
+		return
+	}
+	fmt.Println("error: ", err)
+	printHelp()
+	os.Exit(1)
 }
 
 func main() {
-    argslen := len(os.Args)
-    stripped := make([]string, argslen - 1)
-    for i := 1; i < argslen; i++ {
-        stripped[i - 1] = strings.Trim(os.Args[i], " ")
-    }
-    foundDivider := false
-    command := []string{}
-    for i := 0; i < len(stripped); i++ {
-        if (stripped[i] == "--") {
-            if !foundDivider {
-                foundDivider = true
-                continue
-            }
-        }
-        if !foundDivider {
-            err := parseEnvTerm(stripped[i])
-            handleError(err)
-        } else {
-            command = append(command, stripped[i])
-        }
-    }
-    if !foundDivider {
-        handleError(fmt.Errorf("missing divider (--)"))
-    }
-    parseEnvTerm("@.env")
-    cmd := exec.Command(command[0], command[1:]...)
-    cmd.Env = os.Environ() // herdar env do pai
-    for k, v := range env {
-        cmd.Env = append(cmd.Env, strings.Join([]string{k, v}, "="))
-    }
-    cmd.Stdin = os.Stdin
-    cmd.Stdout = os.Stdout
-    cmd.Stderr = os.Stderr
-    err := cmd.Start()
-    handleError(err)
-    proc, err := cmd.Process.Wait()
-    handleError(err)
-    os.Exit(proc.ExitCode())
+	env := map[string]string{}
+	argslen := len(os.Args)
+	stripped := make([]string, argslen-1)
+	for i := 1; i < argslen; i++ {
+		stripped[i-1] = strings.Trim(os.Args[i], " ")
+	}
+	foundDivider := false
+	command := []string{}
+	for i := 0; i < len(stripped); i++ {
+		if stripped[i] == "--" {
+			if !foundDivider {
+				foundDivider = true
+				continue
+			}
+		}
+		if !foundDivider {
+			err := parseEnvTerm(stripped[i], env)
+			handleError(err)
+		} else {
+			command = append(command, stripped[i])
+		}
+	}
+	if !foundDivider {
+		handleError(fmt.Errorf("missing divider (--)"))
+	}
+	parseEnvTerm("@.env", env)
+	cmd := exec.Command(command[0], command[1:]...)
+	cmd.Env = os.Environ() // herdar env do pai
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, strings.Join([]string{k, v}, "="))
+	}
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Start()
+	handleError(err)
+	proc, err := cmd.Process.Wait()
+	handleError(err)
+	os.Exit(proc.ExitCode())
 }

--- a/cmd/dotenv/parser.go
+++ b/cmd/dotenv/parser.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/joho/godotenv"
+)
+
+func mergeEnv(env map[string]string, m map[string]string) {
+	for k := range m {
+		env[k] = m[k]
+	}
+}
+
+func parseEnvTerm(term string, env map[string]string) error {
+	if term[0] == '@' {
+		filename := term[1:]
+		f, err := os.Open(filename)
+		defer f.Close()
+		if err != nil {
+			return err
+		}
+		variables, err := godotenv.Parse(f)
+		if err != nil {
+			return err
+		}
+		mergeEnv(env, variables)
+		return nil
+	}
+	if strings.HasPrefix(term, "--") {
+		termBody := term[2:]
+		elems := strings.Split(termBody, "=")
+		if len(elems) != 2 {
+			return fmt.Errorf("syntax error near %s", term)
+		}
+		key := elems[0]
+		value := elems[1]
+		env[key] = value
+		return nil
+	}
+	fmt.Printf("warn: ignoring argument '%s'\n", term)
+	return nil
+}

--- a/package.nix
+++ b/package.nix
@@ -10,6 +10,8 @@ buildGoModule {
 
   src = ./.;
 
+  subPackages = [ "cmd/dotenv" ];
+
   meta = with lib; {
     description = "Dotenv as a binary that loads the dotenv and calls the program";
     homepage = "https://github.com/lucasew/dotenv";


### PR DESCRIPTION
This PR refactors the entrypoint of the project by extracting parsing logic and eliminating global state to improve internal structure and adhere to software engineering principles.

### Context
`main.go` previously contained both process lifecycle execution and `.env` parsing logic, and additionally utilized a global map `env` which decreased functional purity and increased cognitive load.

### Solution
- **Extraction (Extract Method/File)**: Extracted `parseEnvTerm` and `mergeEnv` to `cmd/dotenv/parser.go`. As described by Martin in *Clean Code*, modules should adhere to the Single Responsibility Principle. `main.go` should handle CLI flags, the divider (`--`), and executing the subprocess, while `parser.go` should isolate parsing logic (via strings and `godotenv`).
- **Remove Global State**: Initialized the `env` map locally in `main()` and explicitly passed it to `parseEnvTerm` and `mergeEnv` by reference. This makes the functions purer and more testable.
- **Created `AGENTS.md`**: Codified the project conventions, centralized error reporting (`handleError`), building instructions, and `mise` setup rules to govern future changes.

### Assumptions
- The behavior of `@.env` overriding other arguments remains consistent as it was previously executed at the end of argument processing.
- Extracting parsing into a sibling file `parser.go` within the `main` package does not violate Nix build rules for `cmd/dotenv` as `go build ./cmd/dotenv` encompasses the entire package.

### Alternatives Not Chosen
- Creating a separate package (e.g., `pkg/parser`) for parsing logic. This was avoided because the parsing logic is tightly coupled to the specific CLI structure and sparse directories (single files with no reason to be isolated) should be merged/kept within the domain package.

### How To Pivot
- If the parsing logic needs to become a reusable library across multiple commands or binaries in the future, `parser.go` can be easily relocated to a shared internal package (e.g., `internal/envparser`).
- If you wish to revert to global state, simply recreate `var env = map[string]string{}` in `main.go` and remove the `env map[string]string` parameter from the parsing signatures.

### Next Knobs
- The `handleError` implementation in `main.go` could be expanded to support Sentry or other telemetry frameworks if necessary.
- The `go fmt` enforcement documented in `AGENTS.md` can be integrated directly into a GitHub Actions step.

---
*PR created automatically by Jules for task [1014517945792919149](https://jules.google.com/task/1014517945792919149) started by @lucasew*