### PR TITLE
🧹 Janitor: Fix formatting and swallowed error in main.go

### DIFF
--- a/.jules/janitor.md
+++ b/.jules/janitor.md
@@ -1,0 +1,1 @@
+- 2026-03-12: Ensure returned errors are appropriately handled via centralized error reporting and codebase is formatted with go fmt.

--- a/cmd/dotenv/main.go
+++ b/cmd/dotenv/main.go
@@ -9,97 +9,102 @@ import (
 	"github.com/joho/godotenv"
 )
 
-var env  = map[string]string{}
+var env = map[string]string{}
 
 func mergeEnv(m map[string]string) {
-    for k := range m {
-        env[k] = m[k]
-    }
+	for k := range m {
+		env[k] = m[k]
+	}
 }
 
 func printHelp() {
-    println("dotenv [...params] -- command")
-    println("params: ")
-    println(" @file.txt load file as dotenv")
-    println(" --key=value load variable")
+	println("dotenv [...params] -- command")
+	println("params: ")
+	println(" @file.txt load file as dotenv")
+	println(" --key=value load variable")
 }
 
 func parseEnvTerm(term string) error {
-    if term[0] == '@' {
-        filename := term[1:]
-        f, err := os.Open(filename)
-        defer f.Close()
-        if err != nil {
-            return err
-        }
-        variables, err := godotenv.Parse(f)
-        if err != nil {
-            return err
-        }
-        mergeEnv(variables)
-        return nil
-    }
-    if strings.HasPrefix(term, "--") {
-        termBody := term[2:]
-        elems := strings.Split(termBody, "=")
-        if len(elems) != 2 {
-            return fmt.Errorf("syntax error near %s", term)
-        }
-        key := elems[0]
-        value := elems[1]
-        env[key] = value
-        return nil
-    }
-    fmt.Printf("warn: ignoring argument '%s'\n", term)
-    return nil
+	if term[0] == '@' {
+		filename := term[1:]
+		f, err := os.Open(filename)
+		defer f.Close()
+		if err != nil {
+			return err
+		}
+		variables, err := godotenv.Parse(f)
+		if err != nil {
+			return err
+		}
+		mergeEnv(variables)
+		return nil
+	}
+	if strings.HasPrefix(term, "--") {
+		termBody := term[2:]
+		elems := strings.Split(termBody, "=")
+		if len(elems) != 2 {
+			return fmt.Errorf("syntax error near %s", term)
+		}
+		key := elems[0]
+		value := elems[1]
+		env[key] = value
+		return nil
+	}
+	fmt.Printf("warn: ignoring argument '%s'\n", term)
+	return nil
 }
 
 func handleError(err error) {
-    if err == nil {
-        return
-    }
-    fmt.Println("error: ", err)
-    printHelp()
-    os.Exit(1)
+	if err == nil {
+		return
+	}
+	fmt.Println("error: ", err)
+	printHelp()
+	os.Exit(1)
 }
 
 func main() {
-    argslen := len(os.Args)
-    stripped := make([]string, argslen - 1)
-    for i := 1; i < argslen; i++ {
-        stripped[i - 1] = strings.Trim(os.Args[i], " ")
-    }
-    foundDivider := false
-    command := []string{}
-    for i := 0; i < len(stripped); i++ {
-        if (stripped[i] == "--") {
-            if !foundDivider {
-                foundDivider = true
-                continue
-            }
-        }
-        if !foundDivider {
-            err := parseEnvTerm(stripped[i])
-            handleError(err)
-        } else {
-            command = append(command, stripped[i])
-        }
-    }
-    if !foundDivider {
-        handleError(fmt.Errorf("missing divider (--)"))
-    }
-    parseEnvTerm("@.env")
-    cmd := exec.Command(command[0], command[1:]...)
-    cmd.Env = os.Environ() // herdar env do pai
-    for k, v := range env {
-        cmd.Env = append(cmd.Env, strings.Join([]string{k, v}, "="))
-    }
-    cmd.Stdin = os.Stdin
-    cmd.Stdout = os.Stdout
-    cmd.Stderr = os.Stderr
-    err := cmd.Start()
-    handleError(err)
-    proc, err := cmd.Process.Wait()
-    handleError(err)
-    os.Exit(proc.ExitCode())
+	argslen := len(os.Args)
+	stripped := make([]string, argslen-1)
+	for i := 1; i < argslen; i++ {
+		stripped[i-1] = strings.Trim(os.Args[i], " ")
+	}
+	foundDivider := false
+	command := []string{}
+	for i := 0; i < len(stripped); i++ {
+		if stripped[i] == "--" {
+			if !foundDivider {
+				foundDivider = true
+				continue
+			}
+		}
+		if !foundDivider {
+			err := parseEnvTerm(stripped[i])
+			handleError(err)
+		} else {
+			command = append(command, stripped[i])
+		}
+	}
+	if !foundDivider {
+		handleError(fmt.Errorf("missing divider (--)"))
+	}
+
+	err := parseEnvTerm("@.env")
+	if err != nil && !os.IsNotExist(err) {
+		handleError(err)
+	}
+
+	cmd := exec.Command(command[0], command[1:]...)
+	cmd.Env = os.Environ() // herdar env do pai
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, strings.Join([]string{k, v}, "="))
+	}
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Start()
+	handleError(err)
+	proc, err := cmd.Process.Wait()
+	handleError(err)
+	os.Exit(proc.ExitCode())
 }

--- a/package.nix
+++ b/package.nix
@@ -10,8 +10,6 @@ buildGoModule {
 
   src = ./.;
 
-  subPackages = [ "cmd/dotenv" ];
-
   meta = with lib; {
     description = "Dotenv as a binary that loads the dotenv and calls the program";
     homepage = "https://github.com/lucasew/dotenv";

--- a/package.nix
+++ b/package.nix
@@ -10,6 +10,8 @@ buildGoModule {
 
   src = ./.;
 
+  subPackages = [ "cmd/dotenv" ];
+
   meta = with lib; {
     description = "Dotenv as a binary that loads the dotenv and calls the program";
     homepage = "https://github.com/lucasew/dotenv";


### PR DESCRIPTION
**What Changed:**
- Formatted `cmd/dotenv/main.go` using `go fmt`.
- Addressed a swallowed error from `parseEnvTerm("@.env")` by explicitly checking for an error and reporting it via the centralized `handleError` function, while correctly bypassing expected `os.IsNotExist` errors for missing optional `.env` files.
- Appended a journal entry in `.jules/janitor.md` about properly reporting errors via the centralized handler.

**Why This Helps:**
- Enforces standard code formatting per project conventions.
- Ensures unexpected errors when attempting to load the `.env` file are logged instead of swallowed, making debugging easier if `.env` fails to parse or there are permission issues.
- Adheres to the Janitor directive of keeping a single-sentence insight journal.

**Before/After:**
- Before: `parseEnvTerm("@.env")` error was ignored, and the main file was improperly formatted.
- After: `parseEnvTerm("@.env")` error is captured, bypassed if it's `os.IsNotExist(err)`, and logged otherwise. `cmd/dotenv/main.go` format is consistent.

**Verification:**
- Ran `go vet ./...` and `go test ./...` which show no regressions.
- Verified manual build with `go build ./cmd/dotenv` builds fine.

**Assumptions:**
- `parseEnvTerm("@.env")` returning `os.ErrNotExist` is expected because `.env` files might not be present and should be skipped safely.

**Alternatives Not Chosen:**
- Did not refactor the internal panic bug in `parseEnvTerm` where `defer f.Close()` happens before checking if the error `f, err := os.Open(...)` is `nil` as this was an out-of-scope complexity issue.

**How To Pivot:**
- If you don't want the swallowed error checked, simply remove the error block wrapping `parseEnvTerm("@.env")`.

**Next Knobs:**
- `cmd/dotenv/main.go:121` -> The error bypass condition for `os.IsNotExist`.
- `parseEnvTerm` function logic -> Should be refactored by Refactor agent to fix the potential nil pointer dereference on file open failure.

---
*PR created automatically by Jules for task [4986520501902266079](https://jules.google.com/task/4986520501902266079) started by @lucasew*